### PR TITLE
remove: cutText

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -112,10 +112,10 @@ func HTMLAllowing(s string, args ...[]string) (string, error) {
 							buffer.WriteString(u.Host)
 							// buffer.WriteString(u.Path)
 						} else {
-							buffer.WriteString(cutText(text))
+							buffer.WriteString(text)
 						}
 					} else {
-						buffer.WriteString(cutText(text))
+						buffer.WriteString(text)
 					}
 					buffer.WriteString(" ")
 				}
@@ -129,14 +129,6 @@ func HTMLAllowing(s string, args ...[]string) (string, error) {
 			// We ignore unknown token types by default
 
 		}
-	}
-}
-
-func cutText(s string) string {
-	if len(s) > 30 {
-		return s[0:30]
-	} else {
-		return s
 	}
 }
 


### PR DESCRIPTION
cutText tends to break longer words -  i can't see a reason to do it